### PR TITLE
Fix/testing

### DIFF
--- a/examples/gateway/arbor-example-gateway/main.go
+++ b/examples/gateway/arbor-example-gateway/main.go
@@ -9,5 +9,5 @@ func main() {
 	//Configure Arbor
 	gateway.ConfigArbor()
 	//Register the Routes in a Collection and Boot Arbor
-	arbor.Boot(gateway.RegisterRoutes(), "127.0.0.1", 8000)
+	arbor.Boot(gateway.RegisterRoutes(), "0.0.0.0", 8000)
 }

--- a/examples/gateway/arbor-example-gateway/main.go
+++ b/examples/gateway/arbor-example-gateway/main.go
@@ -9,5 +9,5 @@ func main() {
 	//Configure Arbor
 	gateway.ConfigArbor()
 	//Register the Routes in a Collection and Boot Arbor
-	arbor.Boot(gateway.RegisterRoutes(), 8000)
+	arbor.Boot(gateway.RegisterRoutes(), "127.0.0.1", 8000)
 }

--- a/examples/gateway/product_service.go
+++ b/examples/gateway/product_service.go
@@ -7,7 +7,7 @@ import (
 )
 
 //URL of the Product Service API
-const productServiceURL string = "http://127.0.0.1:5000"
+const productServiceURL string = "http://0.0.0.0:5000"
 
 //Data format of the API
 const productServiceFormat string = "JSON"

--- a/examples/products/service.go
+++ b/examples/products/service.go
@@ -1,6 +1,7 @@
 package products
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -41,7 +42,7 @@ func (a *App) Run() {
 
 func (a *App) Kill() {
 	fmt.Println("Killing example service")
-	a.Srv.Shutdown(nil)
+	a.Srv.Shutdown(context.Background())
 }
 
 func (a *App) initializeRoutes() {

--- a/examples/products/service.go
+++ b/examples/products/service.go
@@ -21,7 +21,7 @@ func NewApp() *App {
 	a.Router = mux.NewRouter()
 	a.Model = newProductModel()
 	a.initializeRoutes()
-	a.Srv = &http.Server{Addr: ":5000", Handler: a.Router}
+	a.Srv = &http.Server{Addr: "0.0.0.0:5000", Handler: a.Router}
 	return a
 }
 

--- a/server.go
+++ b/server.go
@@ -44,7 +44,7 @@ const help = `Usage: executable [-r | --register-client client_name] [-c | --che
 // runs arbor with the security layer
 //
 // It will start the arbor instance, parsing the command arguments and execute the behavior.
-func Boot(routes RouteCollection, port uint16) *server.ArborServer {
+func Boot(routes RouteCollection, addr string, port uint16) *server.ArborServer {
 	var srv *server.ArborServer
 	if len(os.Args) == 3 && (os.Args[1] == "--register-client" || os.Args[1] == "-r") {
 		RegisterClient(os.Args[2])
@@ -52,14 +52,14 @@ func Boot(routes RouteCollection, port uint16) *server.ArborServer {
 		CheckRegistration(os.Args[2])
 	} else if len(os.Args) == 2 && (os.Args[1] == "--unsecured" || os.Args[1] == "-u") {
 		logger.Log(logger.WARN, "Starting Arbor in unsecured mode")
-		srv = server.StartUnsecuredServer(routes.toServiceRoutes(), port)
+		srv = server.StartUnsecuredServer(routes.toServiceRoutes(), addr, port)
 	} else if len(os.Args) == 2 && (os.Args[1] == "--help" || os.Args[1] == "-h") {
 		fmt.Println(help)
 	} else if len(os.Args) > 1 {
 		logger.Log(logger.ERR, "Unknown Command")
 		fmt.Println(help)
 	} else {
-		srv = server.StartSecuredServer(routes.toServiceRoutes(), port)
+		srv = server.StartSecuredServer(routes.toServiceRoutes(), addr, port)
 	}
 	return srv
 }

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"context"
 
 	"github.com/acm-uiuc/arbor/logger"
 	"github.com/acm-uiuc/arbor/security"
@@ -45,7 +46,7 @@ func (a *ArborServer) StartServer() {
 //KillServer ends the http server
 func (a *ArborServer) KillServer() {
 	logger.Log(logger.SPEC, "Pulling up the roots [Shutting down the server...]")
-	a.server.Shutdown(nil)
+	a.server.Shutdown(context.Background())
 	if security.IsEnabled() {
 		security.Shutdown()
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -18,9 +18,9 @@ type ArborServer struct {
 }
 
 //NewServer creates a new ArborSever
-func NewServer(routes services.RouteCollection, port uint16) *ArborServer {
+func NewServer(routes services.RouteCollection, addr string, port uint16) *ArborServer {
 	a := new(ArborServer)
-	a.addr = fmt.Sprintf(":%d", port)
+	a.addr = fmt.Sprintf("%s:%d", addr, port)
 	a.router = NewRouter(routes)
 	a.server = &http.Server{Addr: a.addr, Handler: a.router}
 	return a
@@ -28,7 +28,7 @@ func NewServer(routes services.RouteCollection, port uint16) *ArborServer {
 
 //StartServer starts the http server in a goroutine to start listening
 func (a *ArborServer) StartServer() {
-	logger.Log(logger.SPEC, "Roots being planted [Server is listening on localhost"+a.addr+"]")
+	logger.Log(logger.SPEC, "Roots being planted [Server is listening on "+a.addr+"]")
 
 	go func() {
 		err := a.server.ListenAndServe()
@@ -54,8 +54,8 @@ func (a *ArborServer) KillServer() {
 // StartSecuredServer starts a secured arbor server (Token required for access)
 //
 // Provide a set of routes to serve and a port to serve on.
-func StartSecuredServer(routes services.RouteCollection, port uint16) *ArborServer {
-	srv := NewServer(routes, port)
+func StartSecuredServer(routes services.RouteCollection, addr string, port uint16) *ArborServer {
+	srv := NewServer(routes, addr, port)
 	security.Init()
 	srv.StartServer()
 	return srv
@@ -64,8 +64,8 @@ func StartSecuredServer(routes services.RouteCollection, port uint16) *ArborServ
 // StartUnsecuredServer starts an unsecured arbor server (Token required for access)
 //
 // Provide a set of routes to server and a port to serve on/
-func StartUnsecuredServer(routes services.RouteCollection, port uint16) *ArborServer {
-	srv := NewServer(routes, port)
+func StartUnsecuredServer(routes services.RouteCollection, addr string, port uint16) *ArborServer {
+	srv := NewServer(routes, addr, port)
 	srv.StartServer()
 	return srv
 }

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/acm-uiuc/arbor/server"
 )
 
-const url string = "http://127.0.0.1:8000"
+const url string = "http://0.0.0.0:8000"
 
 type product struct {
 	ID    int     `json:"id"`
@@ -35,7 +35,7 @@ func newTestingServices() *testingServices {
 	t.testService = products.NewApp()
 	t.testService.Run()
 	gateway.ConfigArbor()
-	t.testGateway = arbor.Boot(gateway.RegisterRoutes(), "127.0.0.1", 8000)
+	t.testGateway = arbor.Boot(gateway.RegisterRoutes(), "0.0.0.0", 8000)
 	return t
 }
 

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -43,6 +43,7 @@ func newTestingServices() *testingServices {
 func (t *testingServices) killTestingServices() {
 	t.testGateway.KillServer()
 	t.testService.Kill()
+	time.Sleep(250 * time.Millisecond)
 }
 
 func TestProxyGETEmpty(t *testing.T) {

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -35,7 +35,7 @@ func newTestingServices() *testingServices {
 	t.testService = products.NewApp()
 	t.testService.Run()
 	gateway.ConfigArbor()
-	t.testGateway = arbor.Boot(gateway.RegisterRoutes(), 8000)
+	t.testGateway = arbor.Boot(gateway.RegisterRoutes(), "127.0.0.1", 8000)
 	return t
 }
 

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -36,6 +36,7 @@ func newTestingServices() *testingServices {
 	t.testService.Run()
 	gateway.ConfigArbor()
 	t.testGateway = arbor.Boot(gateway.RegisterRoutes(), "0.0.0.0", 8000)
+	time.Sleep(250 * time.Millisecond)
 	return t
 }
 


### PR DESCRIPTION
Got the test suite to work on travis.

Had to make a couple changes:
- Bind server to `0.0.0.0` instead of `localhost` (this does change the Arbor API slightly, as now `Boot` requires an address name to bind to)
- Add a bit of delay in the test suite to give time for the server to get setup and torn down
- Add non-`nil` contexts to server shutdown

Addresses #24 